### PR TITLE
feat. 정산 처리 완료 시 이벤트 기록을 위한 reply request pattern 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,55 @@
 - Controller에 추상화 된 이벤트 리스너를 통해 Commerce Service로부터 이벤트를 수신합니다. 구현체는 인프라에 구현되어야 합니다.
 - Commerce Service와는 다르게 도메인 모델을 JPA entity로 사용합니다.
 - 정산에 대한 책임만 갖는다 결제 이벤트 추적관리는 오로지 Commerce Server에서 진행한다.
+
+## 메시지 처리 흐름 (Message Consume → 처리)
+
+```mermaid
+flowchart TD
+  K[(Kafka Topic 'wallet')] --> H[KafkaWalletEventHandler.handleSaveSettlement]
+  H -->|빈 메시지| Skip[로그 경고 후 무시]
+  H -->|정상 메시지| P[WalletMessage 파싱] --> U[WalletUseCase.create]
+
+  U --> C{이미 정산됨?}
+  C -- 예 --> ACK1[Kafka ACK] --> End[(종료)]
+  C -- 아니오 --> S[Wallet 저장 & 이벤트 발행]
+
+  S --> ACK2[Kafka ACK]
+  S --> E[WalletSaveCompleteReplyEvent 발행]
+  E --> R[WalletReplySubscriber]
+  R --> O[Order 재조회]
+  O --> RS[ReplyMessageSender -> Kafka 'wallet-reply']
+```
+
+- 소비: `wallet` 토픽에서 메시지 수신 → 공백은 스킵.
+- 처리: JSON → `WalletMessage` 파싱 → `WalletUseCase.create` 실행.
+- 중복 방지: 이미 정산된 주문이면 ACK 후 종료.
+- 저장/후속 이벤트: Wallet 저장 → 트랜잭션 커밋 후 Reply 이벤트 발행 → Reply 메시지를 `wallet-reply` 토픽으로 송신.
+- 커밋: 비즈니스 처리 성공 시 수동 ACK(`MANUAL_IMMEDIATE`).
+
+## DLT 흐름 (실패/재시도/데드레터)
+
+```mermaid
+flowchart TD
+  K[(Kafka Topic 'wallet')] --> H[KafkaWalletEventHandler.handleSaveSettlement]
+  H -->|예외 발생| RT[재시도 3회]
+  RT -->|재시도 모두 실패| DLT[(Kafka Topic 'wallet-dlt')]
+
+  DLT --> DH[WalletDeadLetterHandler.handleDeadLetter]
+  DH --> PD[WalletMessage 파싱]
+  PD --> UF[WalletRepository.updateWalletEventFail]
+  UF --> PC[PaymentClient PUT /api/v1/payments/event-status]
+  DH --> ACK[Kafka ACK]
+```
+
+- 재시도: `@RetryableTopic`(시도 3회, 지수 백오프, `-retry`/`-dlt` 접미사).
+- DLT 전송: 재시도 실패 시 `wallet-dlt`로 이동.
+- DLT 처리: DLT 리스너가 파싱 후 결제 서버에 실패 상태 변경(HTTP PUT) 통지.
+- 커밋: DLT 처리 후 수동 ACK.
+
+참고 코드
+- 컨슈머/ACK/에러핸들러: `infra/src/main/kotlin/me/golf/infra/config/KafkaConfig.kt`
+- 재시도/DLT 설정: `infra/src/main/kotlin/me/golf/infra/config/KafkaRetryableWithDLT.kt`
+- 정상 처리 리스너: `infra/src/main/kotlin/me/golf/infra/domain/wallet/handler/WalletEventHandler.kt`
+- DLT 처리 리스너: `infra/src/main/kotlin/me/golf/infra/domain/wallet/handler/WalletDeadLetterHandler.kt`
+- Reply 전송: `infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt`

--- a/app/src/main/kotlin/me/golf/app/domain/wallet/dto/WalletSaveCompleteReplyEvent.kt
+++ b/app/src/main/kotlin/me/golf/app/domain/wallet/dto/WalletSaveCompleteReplyEvent.kt
@@ -1,0 +1,5 @@
+package me.golf.app.domain.wallet.dto
+
+data class WalletSaveCompleteReplyEvent(
+    val orderId: String
+)

--- a/app/src/main/kotlin/me/golf/app/domain/wallet/service/WalletService.kt
+++ b/app/src/main/kotlin/me/golf/app/domain/wallet/service/WalletService.kt
@@ -1,5 +1,6 @@
-package me.golf.app.domain.wallet
+package me.golf.app.domain.wallet.service
 
+import me.golf.app.domain.wallet.dto.WalletSaveCompleteReplyEvent
 import me.golf.core.common.PageResponse
 import me.golf.core.domain.order.repository.OrderRepository
 import me.golf.core.domain.seller.model.SettlementSummary
@@ -9,6 +10,7 @@ import me.golf.core.domain.wallet.usecase.WalletUseCase
 import me.golf.core.domain.wallet.usecase.command.SettlementSummarySearch
 import me.golf.core.domain.wallet.usecase.command.WalletSaveCommand
 import me.golf.core.domain.wallet.usecase.result.SettlementSummaryResult
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional
 class WalletService(
     private val walletRepository: WalletRepository,
     private val orderRepository: OrderRepository,
+    private val eventPublisher: ApplicationEventPublisher
 ): WalletUseCase {
 
     @Transactional
@@ -29,6 +32,8 @@ class WalletService(
         val sellers = orderRepository.findSellersByOrderId(command.orderId)
 
         sellers.forEach { walletRepository.save(it.toWallet(order)) }
+
+        eventPublisher.publishEvent(WalletSaveCompleteReplyEvent(command.orderId))
     }
 
     override fun getSettlements(search: SettlementSummarySearch): PageResponse<SettlementSummaryResult> {

--- a/app/src/main/kotlin/me/golf/app/domain/wallet/service/WalletService.kt
+++ b/app/src/main/kotlin/me/golf/app/domain/wallet/service/WalletService.kt
@@ -30,8 +30,9 @@ class WalletService(
         }
 
         val sellers = orderRepository.findSellersByOrderId(command.orderId)
+            .map { it.toWallet(order) }
 
-        sellers.forEach { walletRepository.save(it.toWallet(order)) }
+        walletRepository.saveAll(sellers)
 
         eventPublisher.publishEvent(WalletSaveCompleteReplyEvent(command.orderId))
     }

--- a/app/src/main/kotlin/me/golf/app/domain/wallet/subscriber/WalletReplySubscriber.kt
+++ b/app/src/main/kotlin/me/golf/app/domain/wallet/subscriber/WalletReplySubscriber.kt
@@ -1,0 +1,46 @@
+package me.golf.app.domain.wallet.subscriber
+
+import me.golf.app.domain.wallet.dto.WalletSaveCompleteReplyEvent
+import me.golf.core.domain.order.model.Order
+import me.golf.core.domain.order.repository.OrderRepository
+import me.golf.core.domain.wallet.sender.ReplyMessageSender
+import me.golf.core.domain.wallet.sender.payload.WalletSaveReplyPayload
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.util.UUID
+
+@Component
+class WalletReplySubscriber(
+    private val replyMessageSender: ReplyMessageSender,
+    private val orderRepository: OrderRepository
+) {
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun handleWalletSaveCompleteReply(reply: WalletSaveCompleteReplyEvent) {
+        val traceId: String = UUID.randomUUID().toString()
+
+        log.info("정산 정보 저장 완료! reply 이벤트 발행 orderId: {}, traceId: {}", reply.orderId, traceId)
+
+        orderRepository.getById(reply.orderId)
+            .also { replyMessageSender.send(it.toPayload(traceId)) }
+    }
+
+    private fun Order.toPayload(traceId: String): WalletSaveReplyPayload {
+        return WalletSaveReplyPayload(
+            this.id,
+            traceId,
+        )
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(WalletReplySubscriber::class.java)
+    }
+}

--- a/core/src/main/kotlin/me/golf/core/domain/wallet/repository/WalletRepository.kt
+++ b/core/src/main/kotlin/me/golf/core/domain/wallet/repository/WalletRepository.kt
@@ -7,6 +7,7 @@ import me.golf.core.domain.wallet.usecase.command.WalletSaveCommand
 interface WalletRepository {
 
     fun save(wallet: Wallet)
+    fun saveAll(wallets: List<Wallet>)
     fun existsByOrderId(order: Order): Boolean
     fun updateWalletEventFail(command: WalletSaveCommand)
 }

--- a/core/src/main/kotlin/me/golf/core/domain/wallet/sender/ReplyMessageSender.kt
+++ b/core/src/main/kotlin/me/golf/core/domain/wallet/sender/ReplyMessageSender.kt
@@ -1,0 +1,8 @@
+package me.golf.core.domain.wallet.sender
+
+import me.golf.core.domain.wallet.sender.payload.WalletSaveReplyPayload
+
+interface ReplyMessageSender {
+
+    fun send(payload: WalletSaveReplyPayload)
+}

--- a/core/src/main/kotlin/me/golf/core/domain/wallet/sender/payload/WalletSaveReplyPayload.kt
+++ b/core/src/main/kotlin/me/golf/core/domain/wallet/sender/payload/WalletSaveReplyPayload.kt
@@ -1,0 +1,6 @@
+package me.golf.core.domain.wallet.sender.payload
+
+data class WalletSaveReplyPayload(
+    val orderId: String,
+    val traceId: String
+)

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/handler/WalletDeadLetterHandler.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/handler/WalletDeadLetterHandler.kt
@@ -21,8 +21,6 @@ internal class WalletDeadLetterHandlerImpl(
     private val objectMapper: ObjectMapper,
 ): WalletDeadLetterHandler {
 
-    private val log = LoggerFactory.getLogger(this::class.java)
-
     @KafkaListener(
         topics = ["wallet-dlt"],
         groupId = "wallet-dead-letter-group",
@@ -40,5 +38,9 @@ internal class WalletDeadLetterHandlerImpl(
 
         walletRepository.updateWalletEventFail(walletMessage.toCommand())
         acknowledgment.acknowledge()
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(WalletDeadLetterHandler::class.java)
     }
 }

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/repository/WalletRepositoryImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/repository/WalletRepositoryImpl.kt
@@ -18,6 +18,10 @@ class WalletRepositoryImpl(
         walletJpaDao.save(wallet)
     }
 
+    override fun saveAll(wallets: List<Wallet>) {
+        walletJpaDao.saveAll(wallets)
+    }
+
     override fun existsByOrderId(order: Order): Boolean {
         return walletJpaDao.existsByOrder(order)
     }

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
@@ -5,6 +5,7 @@ import me.golf.core.domain.wallet.sender.ReplyMessageSender
 import me.golf.core.domain.wallet.sender.payload.WalletSaveReplyPayload
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.support.SendResult
@@ -15,10 +16,11 @@ import org.springframework.stereotype.Component
 class ReplyMessageKafkaSender(
     private val kafkaTemplate: KafkaTemplate<String, String>,
     private val objectMapper: ObjectMapper,
+    @Value("\${kafka.topics.wallet-reply}") private val walletReplyTopic: String
 ): ReplyMessageSender {
 
     override fun send(payload: WalletSaveReplyPayload) {
-        kafkaTemplate.send(WALLET_REPLY_TOPIC, payload.toJson())
+        kafkaTemplate.send(walletReplyTopic, payload.toJson())
             .whenComplete { result, ex ->
                 handleKafkaResult(
                     result = result,
@@ -38,7 +40,7 @@ class ReplyMessageKafkaSender(
         traceId: String
     ) {
         if (ex != null) {
-            log.error("❌wallet reply 이벤트 처리 실패 orderId: {}, traceId: {}", orderId, traceId)
+            log.error("❌wallet reply 이벤트 처리 실패 orderId: {}, traceId: {}", orderId, traceId, ex)
             return
         }
         log.info("✅ Kafka 성공: ${result?.recordMetadata?.offset()}")
@@ -46,7 +48,6 @@ class ReplyMessageKafkaSender(
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java)
-        private const val WALLET_REPLY_TOPIC = "wallet-reply"
     }
 }
 

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
@@ -31,7 +31,7 @@ class ReplyMessageKafkaSender(
     private fun WalletSaveReplyPayload.toJson(): String = objectMapper.writeValueAsString(this)
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+        private val log: Logger = LoggerFactory.getLogger(ReplyMessageKafkaSender::class.java)
     }
 }
 
@@ -44,6 +44,6 @@ class ReplyMessageDefaultSender: ReplyMessageSender {
     }
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+        private val log: Logger = LoggerFactory.getLogger(ReplyMessageDefaultSender::class.java)
     }
 }

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
@@ -8,7 +8,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.kafka.core.KafkaTemplate
-import org.springframework.kafka.support.SendResult
 import org.springframework.stereotype.Component
 
 @Component
@@ -20,31 +19,16 @@ class ReplyMessageKafkaSender(
 ): ReplyMessageSender {
 
     override fun send(payload: WalletSaveReplyPayload) {
-        kafkaTemplate.send(walletReplyTopic, payload.toJson())
-            .whenComplete { result, ex ->
-                handleKafkaResult(
-                    result = result,
-                    ex = ex,
-                    orderId = payload.orderId,
-                    traceId = payload.traceId
-                )
-            }
+        kotlin.runCatching {
+            kafkaTemplate.send(walletReplyTopic, payload.toJson())
+            log.info("✅ Kafka 성공 orderId {}, tracedId: {}", payload.orderId, payload.traceId)
+        }.onFailure { ex ->
+            log.error("❌wallet reply 이벤트 처리 실패 orderId: {}, traceId: {}", payload.orderId, payload.traceId, ex)
+            throw ex
+        }
     }
 
     private fun WalletSaveReplyPayload.toJson(): String = objectMapper.writeValueAsString(this)
-
-    private fun handleKafkaResult(
-        result: SendResult<String, String>?,
-        ex: Throwable?,
-        orderId: String,
-        traceId: String
-    ) {
-        if (ex != null) {
-            log.error("❌wallet reply 이벤트 처리 실패 orderId: {}, traceId: {}", orderId, traceId, ex)
-            return
-        }
-        log.info("✅ Kafka 성공: ${result?.recordMetadata?.offset()}")
-    }
 
     companion object {
         private val log: Logger = LoggerFactory.getLogger(this::class.java)

--- a/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
+++ b/infra/src/main/kotlin/me/golf/infra/domain/wallet/sender/ReplyMessageSenderImpl.kt
@@ -1,0 +1,64 @@
+package me.golf.infra.domain.wallet.sender
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import me.golf.core.domain.wallet.sender.ReplyMessageSender
+import me.golf.core.domain.wallet.sender.payload.WalletSaveReplyPayload
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import org.springframework.stereotype.Component
+
+@Component
+@Profile("!test")
+class ReplyMessageKafkaSender(
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val objectMapper: ObjectMapper,
+): ReplyMessageSender {
+
+    override fun send(payload: WalletSaveReplyPayload) {
+        kafkaTemplate.send(WALLET_REPLY_TOPIC, payload.toJson())
+            .whenComplete { result, ex ->
+                handleKafkaResult(
+                    result = result,
+                    ex = ex,
+                    orderId = payload.orderId,
+                    traceId = payload.traceId
+                )
+            }
+    }
+
+    private fun WalletSaveReplyPayload.toJson(): String = objectMapper.writeValueAsString(this)
+
+    private fun handleKafkaResult(
+        result: SendResult<String, String>?,
+        ex: Throwable?,
+        orderId: String,
+        traceId: String
+    ) {
+        if (ex != null) {
+            log.error("❌wallet reply 이벤트 처리 실패 orderId: {}, traceId: {}", orderId, traceId)
+            return
+        }
+        log.info("✅ Kafka 성공: ${result?.recordMetadata?.offset()}")
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+        private const val WALLET_REPLY_TOPIC = "wallet-reply"
+    }
+}
+
+@Component
+@Profile("test")
+class ReplyMessageDefaultSender: ReplyMessageSender {
+
+    override fun send(payload: WalletSaveReplyPayload) {
+        log.info("reply message 이벤트 발생: {}", payload.orderId)
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
+}

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -23,6 +23,19 @@ spring:
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
     listener:
       ack-mode: record                   # 수동 커밋 전략 필요시 manual or manual_immediate
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      bootstrap-servers: ${KAFKA_SERVER}
+      properties:
+        security.protocol: PLAINTEXT
+        # 클라이언트 설정 세부화
+        max.block.ms: 5000                 # 메타데이터 요청 타임아웃
+        reconnect.backoff.ms: 1000         # 재연결 시도 간격
+        reconnect.backoff.max.ms: 10000    # 최대 재연결 시도 간격
+        retry.backoff.ms: 1000             # 재시도 간격
+        request.timeout.ms: 30000          # 요청 타임아웃
+        connections.max.idle.ms: 540000    # 연결 유지 시간
 
 payment:
   host: localhost

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -30,16 +30,10 @@ spring:
       bootstrap-servers: ${KAFKA_SERVER}
       properties:
         enable.idempotence: true
-        security.protocol: PLAINTEXT
-        max.in.flight.requests.per.connection: 1
-        delivery.timeout.ms: 60000
-        max.block.ms: 5000                 # 메타데이터 요청 타임아웃
-        reconnect.backoff.ms: 1000         # 재연결 시도 간격
-        reconnect.backoff.max.ms: 10000    # 최대 재연결 시도 간격
-        retry.backoff.ms: 1000             # 재시도 간격
-        request.timeout.ms: 30000          # 요청 타임아웃
-        connections.max.idle.ms: 540000    # 연결 유지 시간
-      retries: 3
+        delivery.timeout.ms: 12000
+        request.timeout.ms: 3000
+        retry.backoff.ms: 500
+      retries: 5
 
 payment:
   host: localhost

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -29,3 +29,7 @@ payment:
   port: 8080
   endpoint:
     update_event: '/api/v1/payments/event-status'
+
+kafka:
+  topics:
+    wallet-reply: 'wallet-reply'

--- a/infra/src/main/resources/application.yml
+++ b/infra/src/main/resources/application.yml
@@ -24,18 +24,22 @@ spring:
     listener:
       ack-mode: record                   # 수동 커밋 전략 필요시 manual or manual_immediate
     producer:
+      acks: all
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
       bootstrap-servers: ${KAFKA_SERVER}
       properties:
+        enable.idempotence: true
         security.protocol: PLAINTEXT
-        # 클라이언트 설정 세부화
+        max.in.flight.requests.per.connection: 1
+        delivery.timeout.ms: 60000
         max.block.ms: 5000                 # 메타데이터 요청 타임아웃
         reconnect.backoff.ms: 1000         # 재연결 시도 간격
         reconnect.backoff.max.ms: 10000    # 최대 재연결 시도 간격
         retry.backoff.ms: 1000             # 재시도 간격
         request.timeout.ms: 30000          # 요청 타임아웃
         connections.max.idle.ms: 540000    # 연결 유지 시간
+      retries: 3
 
 payment:
   host: localhost


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet save now emits a completion reply that downstream services can consume.
  * Replies include orderId and a generated traceId for cross-system tracing.
  * Emission occurs asynchronously after transaction commit; production sends to Kafka, tests log locally.
  * Wallet persistence now supports bulk saves for improved throughput.

* **Documentation**
  * README expanded with message flow, retry/DLT behavior and diagrams.

* **Refactor**
  * Logger moved to a companion/static scope for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->